### PR TITLE
Allow None for base

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ fn hydrate_any<'py>(base: &'py Bound<'py, PyAny>, item: &'py Bound<'py, PyAny>) 
     if let Ok(item) = item.downcast::<PyDict>() {
         if let Ok(base) = base.downcast::<PyDict>() {
             hydrate_dict(base, item)?;
+        } else if base.is_none() {
+            hydrate_dict(&PyDict::new_bound(base.py()), item)?;
         } else {
             return Err(PyValueError::new_err(
                 "type mismatch: item is a dict, but the base was not",
@@ -50,6 +52,9 @@ fn hydrate_any<'py>(base: &'py Bound<'py, PyAny>, item: &'py Bound<'py, PyAny>) 
     } else if let Ok(item) = item.downcast::<PyList>() {
         if let Ok(base) = base.downcast::<PyList>() {
             hydrate_list(base, item)?;
+        } else if base.is_none() {
+            let empty_list: [&str; 0] = [];
+            hydrate_list(&PyList::new_bound(base.py(), &empty_list), item)?;
         } else {
             return Err(PyValueError::new_err(
                 "type mismatch: item is a list, but base is not",

--- a/tests/test_hydrate.py
+++ b/tests/test_hydrate.py
@@ -1,46 +1,53 @@
 from typing import Any
 
 import hydraters
-import pytest
+from hydraters import DO_NOT_MERGE_MARKER
 
 
-@pytest.fixture
-def base() -> dict[str, Any]:
-    return {"a": "first", "b": "second", "c": "third"}
+def test_full_hydrate() -> None:
+    base_item = {"a": "first", "b": "second", "c": "third"}
+    dehydrated: dict[str, Any] = {}
+
+    rehydrated = hydraters.hydrate(base_item, dehydrated)
+    assert rehydrated == base_item
 
 
-def test_equal_hydrate(base: dict[str, Any]) -> None:
-    result = hydraters.hydrate(base, base)
-    assert result == base
+def test_full_nested() -> None:
+    base_item = {"a": "first", "b": "second", "c": {"d": "third"}}
+    dehydrated: dict[str, Any] = {}
+
+    rehydrated = hydraters.hydrate(base_item, dehydrated)
+    assert rehydrated == base_item
 
 
-def test_full_hydrate(base: dict[str, Any]) -> None:
-    result = hydraters.hydrate(base, {})
-    assert result == base
+def test_nested_extra_keys() -> None:
+    base_item = {"a": "first", "b": "second", "c": {"d": "third"}}
+    dehydrated = {"c": {"e": "fourth", "f": "fifth"}}
+    hydrated = hydraters.hydrate(base_item, dehydrated)
 
-
-def test_full_nested(base: dict[str, Any]) -> None:
-    base["c"] = {"d": "third"}
-    result = hydraters.hydrate(base, {})
-    assert result == base
-
-
-def test_nested_exta_keys(base: dict[str, Any]) -> None:
-    base["c"] = {"d": "third"}
-    item = {"c": {"e": "fourth", "f": "fifth"}}
-    result = hydraters.hydrate(base, item)
-    assert result == {
+    assert hydrated == {
         "a": "first",
         "b": "second",
         "c": {"d": "third", "e": "fourth", "f": "fifth"},
     }
 
 
-def test_list_of_dicts_extra_keys(base: dict[str, Any]) -> None:
-    base = {"a": [{"b1": 1, "b2": 2}, "foo", {"c1": 1, "c2": 2}, "bar"]}
-    item = {"a": [{"b3": 3}, "far", {"c3": 3}, "boo"]}
-    result = hydraters.hydrate(base, item)
-    assert result == {
+def test_list_of_dicts_extra_keys() -> None:
+    base_item = {"a": [{"b1": 1, "b2": 2}, {"c1": 1, "c2": 2}]}
+    dehydrated = {"a": [{"b3": 3}, {"c3": 3}]}
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {
+        "a": [{"b1": 1, "b2": 2, "b3": 3}, {"c1": 1, "c2": 2, "c3": 3}],
+    }
+
+
+def test_equal_len_list_of_mixed_types() -> None:
+    base_item = {"a": [{"b1": 1, "b2": 2}, "foo", {"c1": 1, "c2": 2}, "bar"]}
+    dehydrated = {"a": [{"b3": 3}, "far", {"c3": 3}, "boo"]}
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {
         "a": [
             {"b1": 1, "b2": 2, "b3": 3},
             "far",
@@ -50,16 +57,111 @@ def test_list_of_dicts_extra_keys(base: dict[str, Any]) -> None:
     }
 
 
+def test_unequal_len_list() -> None:
+    base_item = {"a": [{"b1": 1}, {"c1": 1}, {"d1": 1}]}
+    dehydrated = {"a": [{"b1": 1, "b2": 2}, {"c1": 1, "c2": 2}]}
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == dehydrated
+
+
 def test_marked_non_merged_fields() -> None:
-    base = {
+    base_item = {
         "a": "first",
         "b": "second",
         "c": {"d": "third", "e": "fourth"},
     }
-    item = {"c": {"e": "𒍟※", "f": "fifth"}}
-    result = hydraters.hydrate(base, item)
-    assert result == {
+    dehydrated = {"c": {"e": DO_NOT_MERGE_MARKER, "f": "fifth"}}
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {
         "a": "first",
         "b": "second",
         "c": {"d": "third", "f": "fifth"},
     }
+
+
+def test_marked_non_merged_fields_in_list() -> None:
+    base_item = {
+        "a": [{"b": "first", "d": "third"}, {"c": "second", "e": "fourth"}],
+    }
+    dehydrated = {
+        "a": [
+            {"d": DO_NOT_MERGE_MARKER},
+            {"e": DO_NOT_MERGE_MARKER, "f": "fifth"},
+        ],
+    }
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {"a": [{"b": "first"}, {"c": "second", "f": "fifth"}]}
+
+
+def test_deeply_nested_dict() -> None:
+    base_item = {"a": {"b": {"c": {"d": "first", "d1": "second"}}}}
+    dehydrated = {"a": {"b": {"c": {"d2": "third"}}}}
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {
+        "a": {"b": {"c": {"d": "first", "d1": "second", "d2": "third"}}},
+    }
+
+
+def test_equal_list_of_non_dicts() -> None:
+    base_item = {"assets": {"thumbnail": {"roles": ["thumbnail"]}}}
+    dehydrated = {"assets": {"thumbnail": {"href": "http://foo.com"}}}
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {
+        "assets": {"thumbnail": {"roles": ["thumbnail"], "href": "http://foo.com"}},
+    }
+
+
+def test_invalid_assets_removed() -> None:
+    base_item = {
+        "type": "Feature",
+        "assets": {
+            "asset1": {"name": "Asset one"},
+            "asset2": {"name": "Asset two"},
+        },
+    }
+
+    dehydrated = {
+        "assets": {
+            "asset1": {"href": "http://foo.com"},
+            "asset2": DO_NOT_MERGE_MARKER,
+        },
+    }
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+
+    assert hydrated == {
+        "type": "Feature",
+        "assets": {"asset1": {"name": "Asset one", "href": "http://foo.com"}},
+    }
+
+
+def test_top_level_base_keys_marked() -> None:
+    base_item = {
+        "single": "Feature",
+        "double": {"nested": "value"},
+        "triple": {"nested": {"deep": "value"}},
+        "included": "value",
+    }
+
+    dehydrated = {
+        "single": DO_NOT_MERGE_MARKER,
+        "double": DO_NOT_MERGE_MARKER,
+        "triple": DO_NOT_MERGE_MARKER,
+        "unique": "value",
+    }
+
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+
+    assert hydrated == {"included": "value", "unique": "value"}
+
+
+def test_base_none() -> None:
+    base_item = {"value": None}
+    dehydrated = {"value": {"a": "b"}}
+    hydrated = hydraters.hydrate(base_item, dehydrated)
+    assert hydrated == {"value": {"a": "b"}}


### PR DESCRIPTION
## What I am changing

- Allow None for `base` (note: not item)

## How I did it

- It was done in https://github.com/stac-utils/pgstac/pull/263 but I missed that test somehow when I ported this over. 
- Do we need to allow `None` for item as well? I don't think so at first glance but maybe we do 🤷🏼 ... that might make things more complicated.

## How you can test it

```shell
maturin develop --uv && pytest
```

cc @mishaschwartz

## Related Issues

- Closes https://github.com/developmentseed/hydraters/issues/7
