### PR TITLE
fix: macos runners for pypi

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -110,9 +110,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
-          - runner: macos-14
+          - runner: macos-latest
             target: aarch64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
I'm going to manually run these (`workflow_dispatch`) to verify the fix. Prompted by https://github.com/developmentseed/hydraters/actions/runs/26515404025 not completing.